### PR TITLE
avoid crash when productin source map for unparseable code (concat.js)

### DIFF
--- a/src/plugin/concat.js
+++ b/src/plugin/concat.js
@@ -2,6 +2,7 @@ import _ from 'lodash'
 import { toFileSystemState } from 'sigh-core/lib/stream'
 import { concatenate as concatSourceMaps } from 'sigh-core/lib/sourceMap'
 import Event from '../Event'
+import { log } from 'sigh-core'
 
 export default function(op, outputPath) {
   var fileExists = false
@@ -32,7 +33,20 @@ export default function(op, outputPath) {
         data += '\n'
         ++offset
       }
-      sourceMaps.push(event.sourceMap)
+
+      var sourceMap
+      try {
+        sourceMap = event.sourceMap
+      }
+      catch (e) {
+        log.warn('\x07could not construct identity source map for %s', event.projectPath)
+        if (e.message)
+          log.warn(e.message)
+      }
+
+      if (sourceMap) {
+        sourceMaps.push(sourceMap)
+      }
 
       if (idx < events.length - 1)
         offsets.push(cumOffset += offset)

--- a/src/test/plugin/concat.spec.js
+++ b/src/test/plugin/concat.spec.js
@@ -35,6 +35,23 @@ describe('concat plugin', () => {
     })
   })
 
+  it('should handle erronous js file without sourcemap', () => {
+      var data = "console.log('test)"
+
+      var event = new Event({
+          basePath: 'root',
+          path: 'root/subdir/output.js',
+          type: 'add',
+          data
+      })
+
+      var stream = Bacon.constant([ event ])
+
+      return concat({ stream }).toPromise(Promise).then(events => {
+        events[0]._sourceMap.sources.length.should.equal(0);
+      })
+  })
+
   xit('strips source map comments when concatenating two javascript files', () => {
   })
 })


### PR DESCRIPTION
Same as the fix for write but for the concat plugin.

Closes #7