### PR TITLE
Support for writing file encodings.

### DIFF
--- a/src/plugin/glob.js
+++ b/src/plugin/glob.js
@@ -17,7 +17,7 @@ export default function(op, ...patterns) {
   op.nextTreeIndex = treeIndex + patterns.length
 
   var newEvent = (type, { path, treeIndex, initPhase = false }) => {
-    var props = { type, path, initPhase, opTreeIndex: treeIndex }
+    var props = { type, path, initPhase, opTreeIndex: treeIndex, encoding: opts.encoding }
     if (opts.basePath)
       props.basePath = opts.basePath
     props.createTime = new Date

--- a/src/plugin/write.js
+++ b/src/plugin/write.js
@@ -34,7 +34,7 @@ export function writeEvent(basePath, event) {
   var outputDir = path.dirname(outputPath)
 
   var promise = ensureDir(path.dirname(outputPath)).then(() => {
-    return writeFile(outputPath, data)
+    return writeFile(outputPath, data, {encoding: event.encoding})
   })
 
   if (event.supportsSourceMap) {

--- a/src/test/plugin/write.spec.js
+++ b/src/test/plugin/write.spec.js
@@ -7,6 +7,7 @@ import write from '../../plugin/write'
 
 var TMP_PATH = 'test/tmp/write'
 var PROJ_PATH = 'subdir/file1.js'
+var PROJ_PATH_BINARY = 'subdir/file2.bin'
 var TMP_FILE = TMP_PATH + '/' + PROJ_PATH
 
 describe('write plugin', () => {
@@ -39,6 +40,20 @@ describe('write plugin', () => {
 
       readFileSync(tmpFile + '.map').toString()
       .should.equal('{"version":3,"sources":["../../../subdir/file1.js"],"names":[],"mappings":"AAAA,KAAK","file":"file1.js","sourcesContent":["var  pumpbaby\\n"]}')
+    })
+  })
+
+  it('write a binary file', () => {
+    var data = new Buffer([0, 1, 2, 3, -1, 5, 6, 7, 0])
+    var stream = Bacon.constant([
+      new Event({ basePath: 'subdir', path: PROJ_PATH_BINARY, type: 'add', data: data.toString('binary'), encoding: 'binary', supportsSourceMap: false })
+    ])
+
+    return write({ stream }, TMP_PATH).toPromise(Promise).then(events => {
+      // subdir stripped from the output path due to basePath
+      var tmpFile = TMP_PATH + '/file2.bin'
+
+      readFileSync(tmpFile).equals(data).should.be.ok
     })
   })
 


### PR DESCRIPTION
Previously, Sigh would corrupt .png, .ogg, .gif files and the like when copying them. Adding an option for file encoding solves this. Requires https://github.com/sighjs/sigh-core/pull/2
